### PR TITLE
Update to work with flutter 2.5 nullability change

### DIFF
--- a/lib/src/networking.dart
+++ b/lib/src/networking.dart
@@ -215,13 +215,13 @@ class BugseeHttpClient implements HttpClient {
 
   @override
   set authenticate(
-      Future<bool> Function(Uri url, String scheme, String realm)? f) {
+      Future<bool> Function(Uri url, String scheme, String? realm)? f) {
     _httpClient.authenticate = f;
   }
 
   @override
   set authenticateProxy(
-      Future<bool> Function(String host, int port, String scheme, String realm)?
+      Future<bool> Function(String host, int port, String scheme, String? realm)?
           f) {
     _httpClient.authenticateProxy = f;
   }


### PR DESCRIPTION
see https://github.com/testfairy/testfairy-flutter/commit/a51a8c13645f2e8c9ea8cbd981dc88708972e00e
error was ../../.pub-cache/git/flutter-bugsee-da8d2a4962502f2ab3c920781b8e836c590b0223/lib/src/networking.dart:219:32: Error: A value of type 'Future<bool> Function(Uri, String, String)?' can't be assigned to a variable of type 'Future<bool> Function(Uri, String, String?)?' because 'String?' is nullable and 'String' isn't.
 - 'Future' is from 'dart:async'.
 - 'Uri' is from 'dart:core'.
    _httpClient.authenticate = f;
                               ^
../../.pub-cache/git/flutter-bugsee-da8d2a4962502f2ab3c920781b8e836c590b0223/lib/src/networking.dart:226:37: Error: A value of type 'Future<bool> Function(String, int, String, String)?' can't be assigned to a variable of type 'Future<bool> Function(String, int, String, String?)?' because 'String?' is nullable and 'String' isn't.
 - 'Future' is from 'dart:async'.
    _httpClient.authenticateProxy = f;
                                    ^